### PR TITLE
Resolve1 add simplecov for spec coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.gem
 Gemfile.lock
+/coverage

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+require 'simplecov'
+SimpleCov.start

--- a/wikibase_representable.gemspec
+++ b/wikibase_representable.gemspec
@@ -37,5 +37,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'diffy', '~> 3.4'
   spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'rspec', '~> 3.13'
+  spec.add_development_dependency 'simplecov', '~> 0.22.0'
+  spec.add_development_dependency 'pry', '~> 0.15.2'
+
   spec.add_development_dependency 'upennlib-rubocop', '~> 1.2.0'
 end

--- a/wikibase_representable.gemspec
+++ b/wikibase_representable.gemspec
@@ -35,10 +35,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'representable', '~> 3.2'
   spec.add_development_dependency 'bundler', '~> 2.5'
   spec.add_development_dependency 'diffy', '~> 3.4'
+  spec.add_development_dependency 'pry', '~> 0.15.2'
   spec.add_development_dependency 'rake', '~> 13.2'
   spec.add_development_dependency 'rspec', '~> 3.13'
   spec.add_development_dependency 'simplecov', '~> 0.22.0'
-  spec.add_development_dependency 'pry', '~> 0.15.2'
-
   spec.add_development_dependency 'upennlib-rubocop', '~> 1.2.0'
 end


### PR DESCRIPTION
@mdholloway this is a suggestion and may be declined. I've added simplecov for test coverage reporting and the pry gem, which I find useful for debugging. Do you think these are appropriate additions to the code? Would you suggest alternatives?